### PR TITLE
add feature to listen to rollout status update

### DIFF
--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/ControllerManagement.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/ControllerManagement.java
@@ -136,6 +136,22 @@ public interface ControllerManagement {
     Action addUpdateActionStatus(@NotNull @Valid ActionStatusCreate create);
 
     /**
+     * Retrieves all active {@link Action}s of a specific target.
+     * 
+     * @param controllerId
+     *            identifies the target to retrieve the actions from
+     * @param distributionSetId
+     *            associated with the actions
+     * @return an action associated with the given target and distributionSetId
+     * 
+     * @throws EntityNotFoundException
+     *             if target with given ID does not exist
+     */
+    @PreAuthorize(SpringEvalExpressions.HAS_AUTH_READ_TARGET)
+    Optional<Action> findActiveActionsByTargetAndDistributionSet(@NotEmpty String controllerId,
+            @NotNull Long distributionSetId);
+
+    /**
      * Retrieves oldest {@link Action} that is active and assigned to a
      * {@link Target}.
      * 

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/DeploymentManagement.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/DeploymentManagement.java
@@ -364,23 +364,6 @@ public interface DeploymentManagement {
     Page<Action> findActiveActionsByTarget(@NotNull Pageable pageable, @NotEmpty String controllerId);
 
     /**
-     * Retrieves all active {@link Action}s of a specific target.
-     * 
-     * @param pageable
-     *            the page request parameter for paging and sorting the result
-     * @param controllerId
-     *            the target associated with the actions
-     * @param distributionSetId
-     *            the distributionSetId associated with the actions    
-     * @return a list of actions associated with the given target
-     * 
-     * @throws EntityNotFoundException
-     *             if target with given ID does not exist
-     */
-    @PreAuthorize(SpringEvalExpressions.HAS_AUTH_READ_TARGET)
-    Page<Action> findActiveActionsByTargetAndDistributionSet(@NotNull Pageable pageable, @NotEmpty String controllerId,@NotNull Long distributionSetId);
-    
-    /**
      * Retrieves all inactive {@link Action}s of a specific target.
      *
      * @param pageable

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/ActionStatusUpdateEvent.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/ActionStatusUpdateEvent.java
@@ -1,0 +1,63 @@
+package org.eclipse.hawkbit.repository.event.remote;
+
+import java.util.List;
+
+import org.eclipse.hawkbit.repository.event.TenantAwareEvent;
+import org.eclipse.hawkbit.repository.model.Action;
+import org.eclipse.hawkbit.repository.model.Action.Status;
+
+/**
+ * Information that represents status of a target for a given distributionSetId.
+ */
+public class ActionStatusUpdateEvent implements TenantAwareEvent {
+    private final Long distributionSetId;
+    private final String targetControllerId;
+    private final String tenant;
+    private final List<String> messages;
+    private final Status status;
+
+    public ActionStatusUpdateEvent(String tenant, Long distributionSetId, String targetControllerId, Status status,
+            List<String> messages) {
+        this.distributionSetId = distributionSetId;
+        this.targetControllerId = targetControllerId;
+        this.tenant = tenant;
+        this.messages = messages;
+        this.status = status;
+    }
+
+    /**
+     * @return distributionSetId to which the current status belongs to.
+     */
+    public Long getDistributionSetId() {
+        return distributionSetId;
+    }
+
+    /**
+     * @return targetId for which the status is available.
+     */
+    public String getTargetControllerId() {
+        return targetControllerId;
+    }
+
+    /**
+     * @return the tenant under which the execution is happening.
+     */
+    public String getTenant() {
+        return tenant;
+    }
+
+    /**
+     * @return list of messages associated with the status.
+     */
+    public List<String> getMessages() {
+        return messages;
+    }
+
+    /**
+     * @return the status of the target in the context of distributionSetId.
+     */
+    public Status getStatus() {
+        return status;
+    }
+
+}

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/TargetAssignDistributionSetEvent.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/TargetAssignDistributionSetEvent.java
@@ -15,8 +15,6 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.eclipse.hawkbit.repository.model.Action;
-import org.eclipse.hawkbit.repository.model.NamedEntity;
-import org.eclipse.hawkbit.repository.model.RolloutGroup;
 
 /**
  * TenantAwareEvent that gets sent when a distribution set gets assigned to a
@@ -31,9 +29,6 @@ public class TargetAssignDistributionSetEvent extends RemoteTenantAwareEvent {
     private boolean maintenanceWindowAvailable;
 
     private final Map<String, Long> actions = new HashMap<>();
-    
-    private Long rolloutId;
-
 
     /**
      * Default constructor.
@@ -63,8 +58,7 @@ public class TargetAssignDistributionSetEvent extends RemoteTenantAwareEvent {
         this.maintenanceWindowAvailable = maintenanceWindowAvailable;
         actions.putAll(a.stream().filter(action -> action.getDistributionSet().getId().longValue() == distributionSetId)
                 .collect(Collectors.toMap(action -> action.getTarget().getControllerId(), Action::getId)));
-        
-        this.rolloutId = a.get(0).getRollout().getId();
+
     }
 
     public TargetAssignDistributionSetEvent(final Action action, final String applicationId) {
@@ -82,10 +76,6 @@ public class TargetAssignDistributionSetEvent extends RemoteTenantAwareEvent {
 
     public Map<String, Long> getActions() {
         return actions;
-    }
-    
-    public Long getRolloutId() {
-        return this.rolloutId;
     }
 
 }

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/ActionRepository.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/ActionRepository.java
@@ -202,11 +202,11 @@ public interface ActionRepository extends BaseEntityRepository<JpaAction, Long>,
      * @param active
      *            {@code true} for all actions which are currently active,
      *            {@code false} for inactive
-     * @return a list of actions
+     * @return action that matches the criteria 
      */
     @EntityGraph(value = "Action.ds", type = EntityGraphType.LOAD)
     @Query("Select a from JpaAction a where a.target.controllerId = :controllerId and a.distributionSet.id = :distributionSetId and a.active = :active")
-    Page<Action> findByActiveAndTargetAndDistributionSet(Pageable pageable, @Param("controllerId") String controllerId,
+    Optional<Action> findByActiveAndTargetAndDistributionSet(@Param("controllerId") String controllerId,
             @Param("distributionSetId") Long distributionSetId, @Param("active") boolean active);
 
     /**

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/ActionStatusUpdateHandlerService.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/ActionStatusUpdateHandlerService.java
@@ -1,0 +1,84 @@
+package org.eclipse.hawkbit.repository.jpa;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.eclipse.hawkbit.im.authentication.SpPermission.SpringEvalExpressions;
+import org.eclipse.hawkbit.im.authentication.TenantAwareAuthenticationDetails;
+import org.eclipse.hawkbit.repository.ControllerManagement;
+import org.eclipse.hawkbit.repository.EntityFactory;
+import org.eclipse.hawkbit.repository.builder.ActionStatusCreate;
+import org.eclipse.hawkbit.repository.event.remote.ActionStatusUpdateEvent;
+import org.eclipse.hawkbit.repository.model.Action;
+import org.eclipse.hawkbit.repository.model.Action.Status;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.event.EventListener;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.context.SecurityContextImpl;
+
+/**
+ * A service that listens and processes the TargetStatusForDistributionSetEvent
+ *
+ */
+public class ActionStatusUpdateHandlerService {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ActionStatusUpdateHandlerService.class);
+
+    private final ControllerManagement controllerManagement;
+    private final EntityFactory entityFactory;
+
+    public ActionStatusUpdateHandlerService(final ControllerManagement controllerManagement,
+            final EntityFactory entityFactory) {
+        this.controllerManagement = controllerManagement;
+        this.entityFactory = entityFactory;
+    }
+
+    @EventListener(classes = ActionStatusUpdateEvent.class)
+    public void handle(final ActionStatusUpdateEvent event) {
+        Optional<Action> action = controllerManagement.findActiveActionsByTargetAndDistributionSet(event.getTargetControllerId(),
+                event.getDistributionSetId());
+        if (action.isPresent()) {
+            final SecurityContext oldContext = SecurityContextHolder.getContext();
+            try {
+                this.updateStatus(action.get(), event.getTenant(), event.getMessages(), event.getStatus());
+            } finally {
+                SecurityContextHolder.setContext(oldContext);
+            }
+        }
+    }
+
+    protected void setTenantSecurityContext(String tenantId) {
+        final AnonymousAuthenticationToken authenticationToken = new AnonymousAuthenticationToken(
+                UUID.randomUUID().toString(), "Target-Status-Controller",
+                Collections.singletonList(new SimpleGrantedAuthority(SpringEvalExpressions.CONTROLLER_ROLE_ANONYMOUS)));
+        authenticationToken.setDetails(new TenantAwareAuthenticationDetails(tenantId, true));
+        setSecurityContext(authenticationToken);
+    }
+
+    private static void setSecurityContext(final Authentication authentication) {
+        final SecurityContextImpl securityContextImpl = new SecurityContextImpl();
+        securityContextImpl.setAuthentication(authentication);
+        SecurityContextHolder.setContext(securityContextImpl);
+    }
+
+    private Action updateStatus(Action action, String tenant, List<String> messages, Status status) {
+        // attempt to avoid permission issue. Not happening
+        setTenantSecurityContext(tenant);
+
+        final ActionStatusCreate actionStatus = entityFactory.actionStatus().create(action.getId()).status(status)
+                .messages(messages);
+        if (Status.CANCELED.equals(status)) {
+            return controllerManagement.addCancelActionStatus(actionStatus);
+        } else {
+            return controllerManagement.addUpdateActionStatus(actionStatus);
+        }
+    }
+
+}

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaControllerManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaControllerManagement.java
@@ -573,6 +573,13 @@ public class JpaControllerManagement implements ControllerManagement {
         }
         return handleAddUpdateActionStatus(actionStatus, action);
     }
+    
+    
+    @Override
+    public Optional<Action> findActiveActionsByTargetAndDistributionSet(final String controllerId,final Long distributionSetId) {
+        throwExceptionIfTargetDoesNotExist(controllerId);
+        return actionRepository.findByActiveAndTargetAndDistributionSet(controllerId,distributionSetId, true);
+    }
 
     private boolean actionIsNotActiveButIntermediateFeedbackStillAllowed(final ActionStatus actionStatus,
             final boolean actionActive) {

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaDeploymentManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaDeploymentManagement.java
@@ -616,12 +616,6 @@ public class JpaDeploymentManagement implements DeploymentManagement {
         throwExceptionIfTargetDoesNotExist(controllerId);
         return actionRepository.findByActiveAndTarget(pageable, controllerId, true);
     }
-    
-    @Override
-    public Page<Action> findActiveActionsByTargetAndDistributionSet(final Pageable pageable, final String controllerId,final Long distributionSetId) {
-        throwExceptionIfTargetDoesNotExist(controllerId);
-        return actionRepository.findByActiveAndTargetAndDistributionSet(pageable, controllerId,distributionSetId, true);
-    }
 
     @Override
     public Page<Action> findInActiveActionsByTarget(final Pageable pageable, final String controllerId) {

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/RepositoryApplicationConfiguration.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/RepositoryApplicationConfiguration.java
@@ -854,4 +854,10 @@ public class RepositoryApplicationConfiguration extends JpaBaseConfiguration {
             final RolloutManagement rolloutManagement, final SystemSecurityContext systemSecurityContext) {
         return new RolloutScheduler(systemManagement, rolloutManagement, systemSecurityContext);
     }
+
+    @Bean
+    ActionStatusUpdateHandlerService actionStatusHandlerService(final ControllerManagement controllerManagement,
+            final EntityFactory entityFactory) {
+        return new ActionStatusUpdateHandlerService(controllerManagement, entityFactory);
+    }
 }

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/ActionStatusUpdateHandlerServiceTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/ActionStatusUpdateHandlerServiceTest.java
@@ -1,0 +1,116 @@
+package org.eclipse.hawkbit.repository.jpa;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+
+import java.util.ArrayList;
+import java.util.Optional;
+
+import org.eclipse.hawkbit.repository.event.remote.ActionStatusUpdateEvent;
+import org.eclipse.hawkbit.repository.jpa.model.JpaAction;
+import org.eclipse.hawkbit.repository.jpa.model.JpaDistributionSet;
+import org.eclipse.hawkbit.repository.jpa.model.JpaDistributionSetType;
+import org.eclipse.hawkbit.repository.jpa.model.JpaSoftwareModule;
+import org.eclipse.hawkbit.repository.jpa.model.JpaSoftwareModuleType;
+import org.eclipse.hawkbit.repository.jpa.model.JpaTarget;
+import org.eclipse.hawkbit.repository.model.Action;
+import org.eclipse.hawkbit.repository.model.Action.ActionType;
+import org.eclipse.hawkbit.repository.model.Action.Status;
+import org.eclipse.hawkbit.repository.model.DistributionSet;
+import org.eclipse.hawkbit.repository.model.Target;
+import org.junit.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import io.qameta.allure.Description;
+import io.qameta.allure.Feature;
+import io.qameta.allure.Story;
+
+/**
+ * Junit tests for RolloutStatusHandlerService.
+ */
+@ActiveProfiles({ "test" })
+@Feature("Component Tests - Repository")
+@Story("Rollout Status Handler")
+@SpringBootTest(classes = { RepositoryApplicationConfiguration.class })
+public class ActionStatusUpdateHandlerServiceTest extends AbstractJpaIntegrationTest {
+
+    @Test
+    @Description("Verifies that the status update(finished state) for a distribution id marks")
+    public void test() {
+
+        String controllerId = "com.bosch.iot.dm.ac:cac";
+        String tenant = "test";
+
+        // generate data in database
+        JpaSoftwareModule swModule = this.generateSoftwareModule(tenant);
+        JpaDistributionSet ds = generateDistributionSet(swModule, tenant);
+        JpaTarget target = generateSampleTarget(1L, controllerId, tenant);
+        JpaAction action = generateAction(ds, target, tenant);
+
+        ActionStatusUpdateHandlerService rolloutStatusHandlerService = new ActionStatusUpdateHandlerService(
+                this.controllerManagement, this.entityFactory);
+
+        // initiate the test
+        ActionStatusUpdateEvent targetStatus = new ActionStatusUpdateEvent("default",
+                ds.getId(), controllerId, Status.FINISHED, new ArrayList<>());
+        rolloutStatusHandlerService.handle(targetStatus);
+
+        // verify if intended dataSetId is really installed
+        Long installedId = this.targetRepository.findById(target.getId()).get().getInstalledDistributionSet().getId();
+        assertEquals("Status update for a given distirbution set has failed", installedId, ds.getId());
+        
+        // verify that action is database is marked inactive.
+        Optional<Action> activeAction = this.actionRepository.findByActiveAndTargetAndDistributionSet(target.getControllerId(), ds.getId(), true);
+        assertFalse(activeAction.isPresent());
+        
+        // clean up data - start
+        this.actionRepository.deleteById(action.getId());
+        this.softwareModuleRepository.deleteById(swModule.getId());
+        this.targetRepository.deleteById(target.getId());
+        this.distributionSetRepository.deleteById(ds.getId());
+    }
+
+    private JpaDistributionSet generateDistributionSet(JpaSoftwareModule swModule, String tenant) {
+        // TODO Auto-generated method stub
+        JpaDistributionSet ds = new JpaDistributionSet();
+        // ds.setId(distributionSetId);
+        ds.setName("test ds");
+        ds.setVersion("v1");
+        JpaDistributionSetType type = this.distributionSetTypeRepository.findById(4L).get();
+        ds.setType(type);
+        ds.setTenant(tenant);
+        ds.addModule(swModule);
+        ds.setRequiredMigrationStep(false);
+        return this.distributionSetRepository.save(ds);
+    }
+
+    private JpaSoftwareModule generateSoftwareModule(String tenant) {
+        JpaSoftwareModuleType type = this.softwareModuleTypeRepository.findById(3L).get();
+        JpaSoftwareModule swMod = new JpaSoftwareModule(type, "test swm", "0.0.1", "", "");
+        swMod.setId(1L);
+        swMod.setTenant(tenant);
+        return this.softwareModuleRepository.save(swMod);
+    }
+
+    private JpaAction generateAction(DistributionSet distributionSet, Target target, String tenant) {
+        final JpaAction action = new JpaAction();
+        action.setActive(true);
+        action.setDistributionSet(distributionSet);
+        action.setActionType(ActionType.FORCED);
+        action.setTenant(tenant);
+        action.setStatus(Status.SCHEDULED);
+        action.setTarget(target);
+        return actionRepository.save(action);
+    }
+
+    private JpaTarget generateSampleTarget(Long id, String controllerId, String tenant) {
+        JpaTarget jpaTarget = new JpaTarget(controllerId);
+        jpaTarget.setId(id);
+        jpaTarget.setTenant(tenant);
+        jpaTarget.setName("device " + controllerId);
+        return this.targetRepository.save(jpaTarget);
+    }
+
+}


### PR DESCRIPTION
With this feature, extensions can update back the status of a given
rollout using an event(containing distributionSetId and targetId).