### PR TITLE
External ref for actions and status-update events

### DIFF
--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/ControllerManagement.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/ControllerManagement.java
@@ -136,6 +136,22 @@ public interface ControllerManagement {
     Action addUpdateActionStatus(@NotNull @Valid ActionStatusCreate create);
 
     /**
+     * Retrieves all active {@link Action}s of a specific target.
+     * 
+     * @param controllerId
+     *            identifies the target to retrieve the actions from
+     * @param distributionSetId
+     *            associated with the actions
+     * @return an action associated with the given target and distributionSetId
+     * 
+     * @throws EntityNotFoundException
+     *             if target with given ID does not exist
+     */
+    @PreAuthorize(SpringEvalExpressions.HAS_AUTH_READ_TARGET)
+    Optional<Action> findActiveActionsByTargetAndDistributionSet(@NotEmpty String controllerId,
+            @NotNull Long distributionSetId);
+
+    /**
      * Retrieves oldest {@link Action} that is active and assigned to a
      * {@link Target}.
      * 

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/ControllerManagement.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/ControllerManagement.java
@@ -136,22 +136,6 @@ public interface ControllerManagement {
     Action addUpdateActionStatus(@NotNull @Valid ActionStatusCreate create);
 
     /**
-     * Retrieves all active {@link Action}s of a specific target.
-     * 
-     * @param controllerId
-     *            identifies the target to retrieve the actions from
-     * @param distributionSetId
-     *            associated with the actions
-     * @return an action associated with the given target and distributionSetId
-     * 
-     * @throws EntityNotFoundException
-     *             if target with given ID does not exist
-     */
-    @PreAuthorize(SpringEvalExpressions.HAS_AUTH_READ_TARGET)
-    Optional<Action> findActiveActionsByTargetAndDistributionSet(@NotEmpty String controllerId,
-            @NotNull Long distributionSetId);
-
-    /**
      * Retrieves oldest {@link Action} that is active and assigned to a
      * {@link Target}.
      * 

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/ControllerManagement.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/ControllerManagement.java
@@ -416,14 +416,18 @@ public interface ControllerManagement {
      */
     @PreAuthorize(SpringEvalExpressions.IS_CONTROLLER)
     Action cancelAction(long actionId);
-    
-    /** Updates given {@link Action} with its external id.
-     * @param actionId to be updated
-     * @param externalRef of the action
+
+    /**
+     * Updates given {@link Action} with its external id.
+     * 
+     * @param actionId
+     *            to be updated
+     * @param externalRef
+     *            of the action
      */
     @PreAuthorize(SpringEvalExpressions.IS_CONTROLLER)
-    void updateActionExternalRef(long actionId,String externalRef);
-    
+    void updateActionExternalRef(long actionId, @NotEmpty String externalRef);
+
     @PreAuthorize(SpringEvalExpressions.IS_CONTROLLER)
     /**
      * Retrieves list of {@link Action}s which matches the provided
@@ -433,5 +437,5 @@ public interface ControllerManagement {
      *            for which the actions need to be fetched.
      * @return
      */
-    List<Action> getActiveActionsByExternalRef(List<String> externalRefs);
+    List<Action> getActiveActionsByExternalRef(@NotNull List<String> externalRefs);
 }

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/ControllerManagement.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/ControllerManagement.java
@@ -416,4 +416,22 @@ public interface ControllerManagement {
      */
     @PreAuthorize(SpringEvalExpressions.IS_CONTROLLER)
     Action cancelAction(long actionId);
+    
+    /** Updates given {@link Action} with its external id.
+     * @param actionId to be updated
+     * @param externalRef of the action
+     */
+    @PreAuthorize(SpringEvalExpressions.IS_CONTROLLER)
+    void updateActionExternalRef(long actionId,String externalRef);
+    
+    @PreAuthorize(SpringEvalExpressions.IS_CONTROLLER)
+    /**
+     * Retrieves list of {@link Action}s which matches the provided
+     * externalRefs.
+     * 
+     * @param externalRefs
+     *            for which the actions need to be fetched.
+     * @return
+     */
+    List<Action> getActiveActionsByExternalRef(List<String> externalRefs);
 }

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/ActionStatusUpdateEvent.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/ActionStatusUpdateEvent.java
@@ -1,42 +1,40 @@
+/**
+ * Copyright (c) 2019 Bosch Software Innovations GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
 package org.eclipse.hawkbit.repository.event.remote;
 
 import java.util.List;
 
 import org.eclipse.hawkbit.repository.event.TenantAwareEvent;
-import org.eclipse.hawkbit.repository.model.Action;
 import org.eclipse.hawkbit.repository.model.Action.Status;
 
 /**
- * Information that represents status of a target for a given distributionSetId.
+ * Information that represents status of a target for a given actionId.
  */
 public class ActionStatusUpdateEvent implements TenantAwareEvent {
-    private final Long distributionSetId;
-    private final String targetControllerId;
+    private final Long actionId;
     private final String tenant;
     private final List<String> messages;
     private final Status status;
 
-    public ActionStatusUpdateEvent(String tenant, Long distributionSetId, String targetControllerId, Status status,
+    public ActionStatusUpdateEvent(String tenant, Long actionId, Status status,
             List<String> messages) {
-        this.distributionSetId = distributionSetId;
-        this.targetControllerId = targetControllerId;
+        this.actionId = actionId;
         this.tenant = tenant;
         this.messages = messages;
         this.status = status;
     }
 
     /**
-     * @return distributionSetId to which the current status belongs to.
+     * @return the actionId for which the status is available.
      */
-    public Long getDistributionSetId() {
-        return distributionSetId;
-    }
-
-    /**
-     * @return targetId for which the status is available.
-     */
-    public String getTargetControllerId() {
-        return targetControllerId;
+    public Long getActionId() {
+        return actionId;
     }
 
     /**

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/ActionStatusUpdateEvent.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/ActionStatusUpdateEvent.java
@@ -22,8 +22,8 @@ public class ActionStatusUpdateEvent implements TenantAwareEvent {
     private final List<String> messages;
     private final Status status;
 
-    public ActionStatusUpdateEvent(String tenant, Long actionId, Status status,
-            List<String> messages) {
+    public ActionStatusUpdateEvent(final String tenant, final Long actionId, final Status status,
+            final List<String> messages) {
         this.actionId = actionId;
         this.tenant = tenant;
         this.messages = messages;

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/ActionStatusUpdateEvent.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/ActionStatusUpdateEvent.java
@@ -1,0 +1,63 @@
+package org.eclipse.hawkbit.repository.event.remote;
+
+import java.util.List;
+
+import org.eclipse.hawkbit.repository.event.TenantAwareEvent;
+import org.eclipse.hawkbit.repository.model.Action;
+import org.eclipse.hawkbit.repository.model.Action.Status;
+
+/**
+ * Information that represents status of a target for a given distributionSetId.
+ */
+public class ActionStatusUpdateEvent implements TenantAwareEvent {
+    private final Long distributionSetId;
+    private final String targetControllerId;
+    private final String tenant;
+    private final List<String> messages;
+    private final Status status;
+
+    public ActionStatusUpdateEvent(String tenant, Long distributionSetId, String targetControllerId, Status status,
+            List<String> messages) {
+        this.distributionSetId = distributionSetId;
+        this.targetControllerId = targetControllerId;
+        this.tenant = tenant;
+        this.messages = messages;
+        this.status = status;
+    }
+
+    /**
+     * @return distributionSetId to which the current status belongs to.
+     */
+    public Long getDistributionSetId() {
+        return distributionSetId;
+    }
+
+    /**
+     * @return targetId for which the status is available.
+     */
+    public String getTargetControllerId() {
+        return targetControllerId;
+    }
+
+    /**
+     * @return the tenant under which the execution is happening.
+     */
+    public String getTenant() {
+        return tenant;
+    }
+
+    /**
+     * @return list of messages associated with the status.
+     */
+    public List<String> getMessages() {
+        return messages;
+    }
+
+    /**
+     * @return the status of the target in the context of distributionSetId.
+     */
+    public Status getStatus() {
+        return status;
+    }
+
+}

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/ActionStatusUpdateEvent.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/ActionStatusUpdateEvent.java
@@ -10,6 +10,9 @@ package org.eclipse.hawkbit.repository.event.remote;
 
 import java.util.List;
 
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
+
 import org.eclipse.hawkbit.repository.event.TenantAwareEvent;
 import org.eclipse.hawkbit.repository.model.Action.Status;
 
@@ -22,8 +25,8 @@ public class ActionStatusUpdateEvent implements TenantAwareEvent {
     private final List<String> messages;
     private final Status status;
 
-    public ActionStatusUpdateEvent(final String tenant, final Long actionId, final Status status,
-            final List<String> messages) {
+    public ActionStatusUpdateEvent(@NotEmpty final String tenant, @NotNull final Long actionId,
+            @NotNull final Status status, @NotNull final List<String> messages) {
         this.actionId = actionId;
         this.tenant = tenant;
         this.messages = messages;

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/model/Action.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/model/Action.java
@@ -12,6 +12,8 @@ import java.time.ZonedDateTime;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
+import javax.validation.constraints.NotEmpty;
+
 /**
  * Update operations to be executed by the target.
  */
@@ -35,7 +37,7 @@ public interface Action extends TenantAwareBaseEntity {
     /**
      * Maximum length of external reference.
      */
-    int EXTERNAL_REF_LENGTH = 64;
+    int EXTERNAL_REF_MAX_LENGTH = 64;
     
     /**
      * @return the distributionSet
@@ -106,7 +108,7 @@ public interface Action extends TenantAwareBaseEntity {
     /**
      * @param externalRef associated with this action
      */
-    void setExternalRef(String externalRef);
+    void setExternalRef(@NotEmpty String externalRef);
     
     /**
      * @return externalRef of the action

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/model/Action.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/model/Action.java
@@ -33,6 +33,11 @@ public interface Action extends TenantAwareBaseEntity {
     int MAINTENANCE_WINDOW_TIMEZONE_LENGTH = 8;
 
     /**
+     * Maximum length of external reference.
+     */
+    int EXTERNAL_REF_LENGTH = 64;
+    
+    /**
      * @return the distributionSet
      */
     DistributionSet getDistributionSet();
@@ -97,6 +102,16 @@ public interface Action extends TenantAwareBaseEntity {
      * @return maintenance window time zone related to this {@link Action}.
      */
     String getMaintenanceWindowTimeZone();
+
+    /**
+     * @param externalRef associated with this action
+     */
+    void setExternalRef(String externalRef);
+    
+    /**
+     * @return externalRef of the action
+     */
+    String getExternalRef();
 
     /**
      * checks if the {@link #getForcedTime()} is hit by the given

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/ActionRepository.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/ActionRepository.java
@@ -225,6 +225,17 @@ public interface ActionRepository extends BaseEntityRepository<JpaAction, Long>,
     List<Long> findByTargetIdInAndIsActiveAndActionStatusAndDistributionSetNotRequiredMigrationStep(
             @Param("targetsIds") List<Long> targetIds, @Param("active") boolean active,
             @Param("currentStatus") Action.Status currentStatus);
+    
+    /** Retrieves all {@link Action}s that matches the queried externalRefs.
+     * @param externalRefs
+     *            for which the actions need to be found
+     * @param active
+     *            flag to indicate active/inactive actions
+     * @return list of actions 
+     */
+    @Query("SELECT a FROM JpaAction a WHERE a.externalRef IN :externalRefs AND a.active = :active")
+    List<Action> findByExternalRefInAndIsActive(@Param("externalRefs") List<String> externalRefs,
+            @Param("active") boolean active);
 
     /**
      * Switches the status of actions from one specific status into another for
@@ -490,4 +501,12 @@ public interface ActionRepository extends BaseEntityRepository<JpaAction, Long>,
     @Query("DELETE FROM JpaAction a WHERE a.id IN ?1")
     void deleteByIdIn(Collection<Long> actionIDs);
 
+    /** Updates the externalRef of an action by its actionId.
+     * @param actionId for which the externalRef is being updated.
+     * @param externalRef value of the external reference for the given action id.
+     */
+    @Modifying
+    @Transactional
+    @Query("UPDATE JpaAction a SET a.externalRef = :externalRef WHERE a.id = :actionId")
+    void updateExternalRef(@Param("actionId") Long actionId, @Param("externalRef") String externalRef);
 }

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/ActionRepository.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/ActionRepository.java
@@ -186,6 +186,27 @@ public interface ActionRepository extends BaseEntityRepository<JpaAction, Long>,
     @Query("Select a from JpaAction a where a.target.controllerId = :controllerId and a.active = :active")
     Page<Action> findByActiveAndTarget(Pageable pageable, @Param("controllerId") String controllerId,
             @Param("active") boolean active);
+    
+    /**
+     * Retrieves all {@link Action}s of a specific target and given active flag
+     * ordered by action ID. Loads also the lazy
+     * {@link Action#getDistributionSet()} field.
+     *
+     * @param pageable
+     *            page parameters
+     * @param controllerId
+     *            to search for
+     * @param distributionSetId
+     *            action containing the distributionSetId           
+     * @param active
+     *            {@code true} for all actions which are currently active,
+     *            {@code false} for inactive
+     * @return action that matches the criteria 
+     */
+    @EntityGraph(value = "Action.ds", type = EntityGraphType.LOAD)
+    @Query("Select a from JpaAction a where a.target.controllerId = :controllerId and a.distributionSet.id = :distributionSetId and a.active = :active")
+    Optional<Action> findByActiveAndTargetAndDistributionSet(@Param("controllerId") String controllerId,
+            @Param("distributionSetId") Long distributionSetId, @Param("active") boolean active);
 
     /**
      * Switches the status of actions from one specific status into another,

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/ActionRepository.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/ActionRepository.java
@@ -186,27 +186,6 @@ public interface ActionRepository extends BaseEntityRepository<JpaAction, Long>,
     @Query("Select a from JpaAction a where a.target.controllerId = :controllerId and a.active = :active")
     Page<Action> findByActiveAndTarget(Pageable pageable, @Param("controllerId") String controllerId,
             @Param("active") boolean active);
-    
-    /**
-     * Retrieves all {@link Action}s of a specific target and given active flag
-     * ordered by action ID. Loads also the lazy
-     * {@link Action#getDistributionSet()} field.
-     *
-     * @param pageable
-     *            page parameters
-     * @param controllerId
-     *            to search for
-     * @param distributionSetId
-     *            action containing the distributionSetId           
-     * @param active
-     *            {@code true} for all actions which are currently active,
-     *            {@code false} for inactive
-     * @return action that matches the criteria 
-     */
-    @EntityGraph(value = "Action.ds", type = EntityGraphType.LOAD)
-    @Query("Select a from JpaAction a where a.target.controllerId = :controllerId and a.distributionSet.id = :distributionSetId and a.active = :active")
-    Optional<Action> findByActiveAndTargetAndDistributionSet(@Param("controllerId") String controllerId,
-            @Param("distributionSetId") Long distributionSetId, @Param("active") boolean active);
 
     /**
      * Switches the status of actions from one specific status into another,

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/ActionRepository.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/ActionRepository.java
@@ -233,8 +233,7 @@ public interface ActionRepository extends BaseEntityRepository<JpaAction, Long>,
      *            flag to indicate active/inactive actions
      * @return list of actions 
      */
-    @Query("SELECT a FROM JpaAction a WHERE a.externalRef IN :externalRefs AND a.active = :active")
-    List<Action> findByExternalRefInAndIsActive(@Param("externalRefs") List<String> externalRefs,
+    List<Action> findByExternalRefInAndActive(@Param("externalRefs") List<String> externalRefs,
             @Param("active") boolean active);
 
     /**

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/ActionStatusUpdateHandlerService.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/ActionStatusUpdateHandlerService.java
@@ -1,0 +1,84 @@
+package org.eclipse.hawkbit.repository.jpa;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.eclipse.hawkbit.im.authentication.SpPermission.SpringEvalExpressions;
+import org.eclipse.hawkbit.im.authentication.TenantAwareAuthenticationDetails;
+import org.eclipse.hawkbit.repository.ControllerManagement;
+import org.eclipse.hawkbit.repository.EntityFactory;
+import org.eclipse.hawkbit.repository.builder.ActionStatusCreate;
+import org.eclipse.hawkbit.repository.event.remote.ActionStatusUpdateEvent;
+import org.eclipse.hawkbit.repository.model.Action;
+import org.eclipse.hawkbit.repository.model.Action.Status;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.event.EventListener;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.context.SecurityContextImpl;
+
+/**
+ * A service that listens and processes the TargetStatusForDistributionSetEvent
+ *
+ */
+public class ActionStatusUpdateHandlerService {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ActionStatusUpdateHandlerService.class);
+
+    private final ControllerManagement controllerManagement;
+    private final EntityFactory entityFactory;
+
+    public ActionStatusUpdateHandlerService(final ControllerManagement controllerManagement,
+            final EntityFactory entityFactory) {
+        this.controllerManagement = controllerManagement;
+        this.entityFactory = entityFactory;
+    }
+
+    @EventListener(classes = ActionStatusUpdateEvent.class)
+    public void handle(final ActionStatusUpdateEvent event) {
+        Optional<Action> action = controllerManagement.findActiveActionsByTargetAndDistributionSet(event.getTargetControllerId(),
+                event.getDistributionSetId());
+        if (action.isPresent()) {
+            final SecurityContext oldContext = SecurityContextHolder.getContext();
+            try {
+                this.updateStatus(action.get(), event.getTenant(), event.getMessages(), event.getStatus());
+            } finally {
+                SecurityContextHolder.setContext(oldContext);
+            }
+        }
+    }
+
+    protected void setTenantSecurityContext(String tenantId) {
+        final AnonymousAuthenticationToken authenticationToken = new AnonymousAuthenticationToken(
+                UUID.randomUUID().toString(), "Target-Status-Controller",
+                Collections.singletonList(new SimpleGrantedAuthority(SpringEvalExpressions.CONTROLLER_ROLE_ANONYMOUS)));
+        authenticationToken.setDetails(new TenantAwareAuthenticationDetails(tenantId, true));
+        setSecurityContext(authenticationToken);
+    }
+
+    private static void setSecurityContext(final Authentication authentication) {
+        final SecurityContextImpl securityContextImpl = new SecurityContextImpl();
+        securityContextImpl.setAuthentication(authentication);
+        SecurityContextHolder.setContext(securityContextImpl);
+    }
+
+    private Action updateStatus(Action action, String tenant, List<String> messages, Status status) {
+        // attempt to avoid permission issue. Not happening
+        setTenantSecurityContext(tenant);
+
+        final ActionStatusCreate actionStatus = entityFactory.actionStatus().create(action.getId()).status(status)
+                .messages(messages);
+        if (Status.CANCELED.equals(status)) {
+            return controllerManagement.addCancelActionStatus(actionStatus);
+        } else {
+            return controllerManagement.addUpdateActionStatus(actionStatus);
+        }
+    }
+
+}

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/ActionStatusUpdateHandlerService.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/ActionStatusUpdateHandlerService.java
@@ -11,23 +11,17 @@ package org.eclipse.hawkbit.repository.jpa;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.UUID;
 
 import org.eclipse.hawkbit.im.authentication.SpPermission.SpringEvalExpressions;
-import org.eclipse.hawkbit.im.authentication.TenantAwareAuthenticationDetails;
 import org.eclipse.hawkbit.repository.ControllerManagement;
 import org.eclipse.hawkbit.repository.EntityFactory;
 import org.eclipse.hawkbit.repository.builder.ActionStatusCreate;
 import org.eclipse.hawkbit.repository.event.remote.ActionStatusUpdateEvent;
 import org.eclipse.hawkbit.repository.model.Action;
 import org.eclipse.hawkbit.repository.model.Action.Status;
+import org.eclipse.hawkbit.security.SystemSecurityContext;
 import org.springframework.context.event.EventListener;
-import org.springframework.security.authentication.AnonymousAuthenticationToken;
-import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.core.context.SecurityContext;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.context.SecurityContextImpl;
 
 /**
  * A service that listens and processes the TargetStatusForDistributionSetEvent
@@ -37,39 +31,26 @@ public class ActionStatusUpdateHandlerService {
 
     private final ControllerManagement controllerManagement;
     private final EntityFactory entityFactory;
+    private final SystemSecurityContext securityContext;
 
     public ActionStatusUpdateHandlerService(final ControllerManagement controllerManagement,
-            final EntityFactory entityFactory) {
+            final EntityFactory entityFactory, final SystemSecurityContext securityContext) {
         this.controllerManagement = controllerManagement;
         this.entityFactory = entityFactory;
+        this.securityContext = securityContext;
     }
 
     @EventListener(classes = ActionStatusUpdateEvent.class)
     public void handle(final ActionStatusUpdateEvent event) {
-        final SecurityContext oldContext = SecurityContextHolder.getContext();
-        setTenantSecurityContext(event.getTenant());
-        Optional<Action> action = controllerManagement.findActionWithDetails(event.getActionId());
-        try {
+        List<SimpleGrantedAuthority> authorities = Collections
+                .singletonList(new SimpleGrantedAuthority(SpringEvalExpressions.CONTROLLER_ROLE_ANONYMOUS));
+        securityContext.runWithAuthority(() -> {
+            Optional<Action> action = controllerManagement.findActionWithDetails(event.getActionId());
             if (action.isPresent() && action.get().isActive()) {
-                this.updateStatus(action.get(), event.getMessages(), event.getStatus());
+                return this.updateStatus(action.get(), event.getMessages(), event.getStatus());
             }
-        } finally {
-            SecurityContextHolder.setContext(oldContext);
-        }
-    }
-
-    protected void setTenantSecurityContext(final String tenantId) {
-        final AnonymousAuthenticationToken authenticationToken = new AnonymousAuthenticationToken(
-                UUID.randomUUID().toString(), "Target-Status-Controller",
-                Collections.singletonList(new SimpleGrantedAuthority(SpringEvalExpressions.CONTROLLER_ROLE_ANONYMOUS)));
-        authenticationToken.setDetails(new TenantAwareAuthenticationDetails(tenantId, true));
-        setSecurityContext(authenticationToken);
-    }
-
-    private static void setSecurityContext(final Authentication authentication) {
-        final SecurityContextImpl securityContextImpl = new SecurityContextImpl();
-        securityContextImpl.setAuthentication(authentication);
-        SecurityContextHolder.setContext(securityContextImpl);
+            return action;
+        }, authorities, event.getTenant());
     }
 
     private Action updateStatus(final Action action, final List<String> messages, final Status status) {

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaControllerManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaControllerManagement.java
@@ -572,13 +572,6 @@ public class JpaControllerManagement implements ControllerManagement {
                 actionStatus.getStatus(), action.getId());
         return action;
     }
-    
-    
-    @Override
-    public Optional<Action> findActiveActionsByTargetAndDistributionSet(final String controllerId,final Long distributionSetId) {
-        throwExceptionIfTargetDoesNotExist(controllerId);
-        return actionRepository.findByActiveAndTargetAndDistributionSet(controllerId,distributionSetId, true);
-    }
 
     /**
      * ActionStatus updates are allowed mainly if the action is active. If the

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaControllerManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaControllerManagement.java
@@ -572,6 +572,13 @@ public class JpaControllerManagement implements ControllerManagement {
                 actionStatus.getStatus(), action.getId());
         return action;
     }
+    
+    
+    @Override
+    public Optional<Action> findActiveActionsByTargetAndDistributionSet(final String controllerId,final Long distributionSetId) {
+        throwExceptionIfTargetDoesNotExist(controllerId);
+        return actionRepository.findByActiveAndTargetAndDistributionSet(controllerId,distributionSetId, true);
+    }
 
     /**
      * ActionStatus updates are allowed mainly if the action is active. If the

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaControllerManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaControllerManagement.java
@@ -36,6 +36,8 @@ import javax.persistence.Query;
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.Root;
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
 
 import org.eclipse.hawkbit.repository.ControllerManagement;
 import org.eclipse.hawkbit.repository.EntityFactory;
@@ -364,8 +366,8 @@ public class JpaControllerManagement implements ControllerManagement {
     }
 
     @Override
-    public List<Action> getActiveActionsByExternalRef(final List<String> externalRefs) {
-        return actionRepository.findByExternalRefInAndIsActive(externalRefs, true);
+    public List<Action> getActiveActionsByExternalRef(@NotNull final List<String> externalRefs) {
+        return actionRepository.findByExternalRefInAndActive(externalRefs, true);
     }
 
     @Override
@@ -1031,7 +1033,7 @@ public class JpaControllerManagement implements ControllerManagement {
     }
 
     @Override
-    public void updateActionExternalRef(final long actionId, final String externalRef) {
+    public void updateActionExternalRef(final long actionId, @NotEmpty final String externalRef) {
         actionRepository.updateExternalRef(actionId, externalRef);
     }
 

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaControllerManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaControllerManagement.java
@@ -364,6 +364,11 @@ public class JpaControllerManagement implements ControllerManagement {
     }
 
     @Override
+    public List<Action> getActiveActionsByExternalRef(final List<String> externalRefs) {
+        return actionRepository.findByExternalRefInAndIsActive(externalRefs, true);
+    }
+
+    @Override
     @Transactional
     @Retryable(include = {
             ConcurrencyFailureException.class }, maxAttempts = Constants.TX_RT_MAX, backoff = @Backoff(delay = Constants.TX_RT_DELAY))
@@ -1023,6 +1028,11 @@ public class JpaControllerManagement implements ControllerManagement {
             throw new CancelActionNotAllowedException(
                     "Action [id: " + action.getId() + "] is not active and cannot be canceled");
         }
+    }
+
+    @Override
+    public void updateActionExternalRef(final long actionId, final String externalRef) {
+        actionRepository.updateExternalRef(actionId, externalRef);
     }
 
     private void cancelAssignDistributionSetEvent(final JpaTarget target, final Long actionId) {

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/RepositoryApplicationConfiguration.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/RepositoryApplicationConfiguration.java
@@ -855,9 +855,16 @@ public class RepositoryApplicationConfiguration extends JpaBaseConfiguration {
         return new RolloutScheduler(systemManagement, rolloutManagement, systemSecurityContext);
     }
 
+    
+    /** activates a event handler which listens to {@link ActionStatusUpdateEvent} and updates the status for an action.
+     * @param controllerManagement to set the updated status for an action
+     * @param entityFactory to create action status
+     * @param securityContext to run the queries which are protected for specific authorities.
+     * @return a new {@link ActionStatusUpdateHandlerService} bean.
+     */
     @Bean
-    ActionStatusUpdateHandlerService actionStatusHandlerService(final ControllerManagement controllerManagement,
-            final EntityFactory entityFactory) {
-        return new ActionStatusUpdateHandlerService(controllerManagement, entityFactory);
+    ActionStatusUpdateHandlerService actionStatusUpdate(final ControllerManagement controllerManagement,
+            final EntityFactory entityFactory, final SystemSecurityContext securityContext) {
+        return new ActionStatusUpdateHandlerService(controllerManagement, entityFactory, securityContext);
     }
 }

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/RepositoryApplicationConfiguration.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/RepositoryApplicationConfiguration.java
@@ -854,4 +854,10 @@ public class RepositoryApplicationConfiguration extends JpaBaseConfiguration {
             final RolloutManagement rolloutManagement, final SystemSecurityContext systemSecurityContext) {
         return new RolloutScheduler(systemManagement, rolloutManagement, systemSecurityContext);
     }
+
+    @Bean
+    ActionStatusUpdateHandlerService actionStatusHandlerService(final ControllerManagement controllerManagement,
+            final EntityFactory entityFactory) {
+        return new ActionStatusUpdateHandlerService(controllerManagement, entityFactory);
+    }
 }

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaAction.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaAction.java
@@ -127,7 +127,7 @@ public class JpaAction extends AbstractJpaTenantAwareBaseEntity implements Actio
     @Column(name = "maintenance_time_zone", updatable = false, length = Action.MAINTENANCE_WINDOW_TIMEZONE_LENGTH)
     private String maintenanceWindowTimeZone;
     
-    @Column(name = "external_ref", updatable = false, length = Action.EXTERNAL_REF_LENGTH)
+    @Column(name = "external_ref", length = Action.EXTERNAL_REF_MAX_LENGTH)
     private String externalRef;
 
     @Override
@@ -338,7 +338,7 @@ public class JpaAction extends AbstractJpaTenantAwareBaseEntity implements Actio
 
     @Override
     public void setExternalRef(String externalRef) {
-       this.externalRef = externalRef;
+        this.externalRef = externalRef;
     }
 
     @Override

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaAction.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaAction.java
@@ -126,6 +126,9 @@ public class JpaAction extends AbstractJpaTenantAwareBaseEntity implements Actio
 
     @Column(name = "maintenance_time_zone", updatable = false, length = Action.MAINTENANCE_WINDOW_TIMEZONE_LENGTH)
     private String maintenanceWindowTimeZone;
+    
+    @Column(name = "external_ref", updatable = false, length = Action.EXTERNAL_REF_LENGTH)
+    private String externalRef;
 
     @Override
     public DistributionSet getDistributionSet() {
@@ -331,5 +334,15 @@ public class JpaAction extends AbstractJpaTenantAwareBaseEntity implements Actio
                 return false;
             }
         }
+    }
+
+    @Override
+    public void setExternalRef(String externalRef) {
+       this.externalRef = externalRef;
+    }
+
+    @Override
+    public String getExternalRef() {
+        return externalRef;
     }
 }

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/resources/db/migration/H2/V1_12_12__add_action_external_id___H2.sql
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/resources/db/migration/H2/V1_12_12__add_action_external_id___H2.sql
@@ -1,0 +1,2 @@
+    ALTER TABLE sp_action ADD column external_ref VARCHAR(64);
+    

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/resources/db/migration/H2/V1_12_12__add_action_external_id___H2.sql
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/resources/db/migration/H2/V1_12_12__add_action_external_id___H2.sql
@@ -1,2 +1,3 @@
-    ALTER TABLE sp_action ADD column external_ref VARCHAR(64);
+ALTER TABLE sp_action ADD column external_ref VARCHAR(64);
+
     

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/resources/db/migration/MYSQL/V1_12_12__add_action_external_id___MYSQL.sql
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/resources/db/migration/MYSQL/V1_12_12__add_action_external_id___MYSQL.sql
@@ -1,0 +1,2 @@
+    ALTER TABLE sp_action ADD column external_ref VARCHAR(64);
+    

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/resources/db/migration/MYSQL/V1_12_12__add_action_external_id___MYSQL.sql
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/resources/db/migration/MYSQL/V1_12_12__add_action_external_id___MYSQL.sql
@@ -1,2 +1,3 @@
-    ALTER TABLE sp_action ADD column external_ref VARCHAR(64);
+ALTER TABLE sp_action ADD column external_ref VARCHAR(64);
+
     

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/ActionStatusUpdateHandlerServiceTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/ActionStatusUpdateHandlerServiceTest.java
@@ -47,24 +47,24 @@ public class ActionStatusUpdateHandlerServiceTest extends AbstractJpaIntegration
         JpaSoftwareModule swModule = this.generateSoftwareModule(tenant);
         JpaDistributionSet ds = generateDistributionSet(swModule, tenant);
         JpaTarget target = generateSampleTarget(1L, controllerId, tenant);
-        JpaAction action = generateAction(ds, target, tenant);
+        JpaAction action = generateAction(101L,ds, target, tenant);
 
         ActionStatusUpdateHandlerService rolloutStatusHandlerService = new ActionStatusUpdateHandlerService(
                 this.controllerManagement, this.entityFactory);
 
         // initiate the test
-        ActionStatusUpdateEvent targetStatus = new ActionStatusUpdateEvent("default",
-                ds.getId(), controllerId, Status.FINISHED, new ArrayList<>());
+        ActionStatusUpdateEvent targetStatus = new ActionStatusUpdateEvent("default", action.getId(), Status.FINISHED,
+                new ArrayList<>());
         rolloutStatusHandlerService.handle(targetStatus);
 
         // verify if intended dataSetId is really installed
         Long installedId = this.targetRepository.findById(target.getId()).get().getInstalledDistributionSet().getId();
         assertEquals("Status update for a given distirbution set has failed", installedId, ds.getId());
-        
+
         // verify that action is database is marked inactive.
-        Optional<Action> activeAction = this.actionRepository.findByActiveAndTargetAndDistributionSet(target.getControllerId(), ds.getId(), true);
+        Optional<JpaAction> activeAction = this.actionRepository.findById(action.getId());
         assertFalse(activeAction.isPresent());
-        
+
         // clean up data - start
         this.actionRepository.deleteById(action.getId());
         this.softwareModuleRepository.deleteById(swModule.getId());
@@ -94,8 +94,9 @@ public class ActionStatusUpdateHandlerServiceTest extends AbstractJpaIntegration
         return this.softwareModuleRepository.save(swMod);
     }
 
-    private JpaAction generateAction(DistributionSet distributionSet, Target target, String tenant) {
+    private JpaAction generateAction(Long actionId, DistributionSet distributionSet, Target target, String tenant) {
         final JpaAction action = new JpaAction();
+        action.setId(actionId);
         action.setActive(true);
         action.setDistributionSet(distributionSet);
         action.setActionType(ActionType.FORCED);

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/ActionStatusUpdateHandlerServiceTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/ActionStatusUpdateHandlerServiceTest.java
@@ -1,0 +1,116 @@
+package org.eclipse.hawkbit.repository.jpa;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+
+import java.util.ArrayList;
+import java.util.Optional;
+
+import org.eclipse.hawkbit.repository.event.remote.ActionStatusUpdateEvent;
+import org.eclipse.hawkbit.repository.jpa.model.JpaAction;
+import org.eclipse.hawkbit.repository.jpa.model.JpaDistributionSet;
+import org.eclipse.hawkbit.repository.jpa.model.JpaDistributionSetType;
+import org.eclipse.hawkbit.repository.jpa.model.JpaSoftwareModule;
+import org.eclipse.hawkbit.repository.jpa.model.JpaSoftwareModuleType;
+import org.eclipse.hawkbit.repository.jpa.model.JpaTarget;
+import org.eclipse.hawkbit.repository.model.Action;
+import org.eclipse.hawkbit.repository.model.Action.ActionType;
+import org.eclipse.hawkbit.repository.model.Action.Status;
+import org.eclipse.hawkbit.repository.model.DistributionSet;
+import org.eclipse.hawkbit.repository.model.Target;
+import org.junit.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import io.qameta.allure.Description;
+import io.qameta.allure.Feature;
+import io.qameta.allure.Story;
+
+/**
+ * Junit tests for RolloutStatusHandlerService.
+ */
+@ActiveProfiles({ "test" })
+@Feature("Component Tests - Repository")
+@Story("Rollout Status Handler")
+@SpringBootTest(classes = { RepositoryApplicationConfiguration.class })
+public class ActionStatusUpdateHandlerServiceTest extends AbstractJpaIntegrationTest {
+
+    @Test
+    @Description("Verifies that the status update(finished state) for a distribution id marks")
+    public void test() {
+
+        String controllerId = "com.bosch.iot.dm.ac:cac";
+        String tenant = "test";
+
+        // generate data in database
+        JpaSoftwareModule swModule = this.generateSoftwareModule(tenant);
+        JpaDistributionSet ds = generateDistributionSet(swModule, tenant);
+        JpaTarget target = generateSampleTarget(1L, controllerId, tenant);
+        JpaAction action = generateAction(ds, target, tenant);
+
+        ActionStatusUpdateHandlerService rolloutStatusHandlerService = new ActionStatusUpdateHandlerService(
+                this.controllerManagement, this.entityFactory);
+
+        // initiate the test
+        ActionStatusUpdateEvent targetStatus = new ActionStatusUpdateEvent("default",
+                ds.getId(), controllerId, Status.FINISHED, new ArrayList<>());
+        rolloutStatusHandlerService.handle(targetStatus);
+
+        // verify if intended dataSetId is really installed
+        Long installedId = this.targetRepository.findById(target.getId()).get().getInstalledDistributionSet().getId();
+        assertEquals("Status update for a given distirbution set has failed", installedId, ds.getId());
+        
+        // verify that action is database is marked inactive.
+        Optional<Action> activeAction = this.actionRepository.findByActiveAndTargetAndDistributionSet(target.getControllerId(), ds.getId(), true);
+        assertFalse(activeAction.isPresent());
+        
+        // clean up data - start
+        this.actionRepository.deleteById(action.getId());
+        this.softwareModuleRepository.deleteById(swModule.getId());
+        this.targetRepository.deleteById(target.getId());
+        this.distributionSetRepository.deleteById(ds.getId());
+    }
+
+    private JpaDistributionSet generateDistributionSet(JpaSoftwareModule swModule, String tenant) {
+        // TODO Auto-generated method stub
+        JpaDistributionSet ds = new JpaDistributionSet();
+        // ds.setId(distributionSetId);
+        ds.setName("test ds");
+        ds.setVersion("v1");
+        JpaDistributionSetType type = this.distributionSetTypeRepository.findById(4L).get();
+        ds.setType(type);
+        ds.setTenant(tenant);
+        ds.addModule(swModule);
+        ds.setRequiredMigrationStep(false);
+        return this.distributionSetRepository.save(ds);
+    }
+
+    private JpaSoftwareModule generateSoftwareModule(String tenant) {
+        JpaSoftwareModuleType type = this.softwareModuleTypeRepository.findById(3L).get();
+        JpaSoftwareModule swMod = new JpaSoftwareModule(type, "test swm", "0.0.1", "", "");
+        swMod.setId(1L);
+        swMod.setTenant(tenant);
+        return this.softwareModuleRepository.save(swMod);
+    }
+
+    private JpaAction generateAction(DistributionSet distributionSet, Target target, String tenant) {
+        final JpaAction action = new JpaAction();
+        action.setActive(true);
+        action.setDistributionSet(distributionSet);
+        action.setActionType(ActionType.FORCED);
+        action.setTenant(tenant);
+        action.setStatus(Status.SCHEDULED);
+        action.setTarget(target);
+        return actionRepository.save(action);
+    }
+
+    private JpaTarget generateSampleTarget(Long id, String controllerId, String tenant) {
+        JpaTarget jpaTarget = new JpaTarget(controllerId);
+        jpaTarget.setId(id);
+        jpaTarget.setTenant(tenant);
+        jpaTarget.setName("device " + controllerId);
+        return this.targetRepository.save(jpaTarget);
+    }
+
+}

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/ActionStatusUpdateHandlerServiceTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/ActionStatusUpdateHandlerServiceTest.java
@@ -3,6 +3,7 @@ package org.eclipse.hawkbit.repository.jpa;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Optional;
@@ -50,7 +51,7 @@ public class ActionStatusUpdateHandlerServiceTest extends AbstractJpaIntegration
         JpaAction action = generateAction(101L,ds, target, tenant);
 
         ActionStatusUpdateHandlerService rolloutStatusHandlerService = new ActionStatusUpdateHandlerService(
-                this.controllerManagement, this.entityFactory);
+                this.controllerManagement, this.entityFactory,this.systemSecurityContext);
 
         // initiate the test
         ActionStatusUpdateEvent targetStatus = new ActionStatusUpdateEvent("default", action.getId(), Status.FINISHED,
@@ -63,7 +64,8 @@ public class ActionStatusUpdateHandlerServiceTest extends AbstractJpaIntegration
 
         // verify that action is database is marked inactive.
         Optional<JpaAction> activeAction = this.actionRepository.findById(action.getId());
-        assertFalse(activeAction.isPresent());
+        assertTrue(activeAction.isPresent());
+        assertFalse(activeAction.get().isActive());
 
         // clean up data - start
         this.actionRepository.deleteById(action.getId());

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/ActionStatusUpdateHandlerServiceTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/ActionStatusUpdateHandlerServiceTest.java
@@ -31,10 +31,8 @@ import io.qameta.allure.Story;
 /**
  * Junit tests for RolloutStatusHandlerService.
  */
-@ActiveProfiles({ "test" })
 @Feature("Component Tests - Repository")
 @Story("Rollout Status Handler")
-@SpringBootTest(classes = { RepositoryApplicationConfiguration.class })
 public class ActionStatusUpdateHandlerServiceTest extends AbstractJpaIntegrationTest {
 
     @Test
@@ -48,10 +46,10 @@ public class ActionStatusUpdateHandlerServiceTest extends AbstractJpaIntegration
         JpaSoftwareModule swModule = this.generateSoftwareModule(tenant);
         JpaDistributionSet ds = generateDistributionSet(swModule, tenant);
         JpaTarget target = generateSampleTarget(1L, controllerId, tenant);
-        JpaAction action = generateAction(101L,ds, target, tenant);
+        JpaAction action = generateAction(101L, ds, target, tenant);
 
         ActionStatusUpdateHandlerService rolloutStatusHandlerService = new ActionStatusUpdateHandlerService(
-                this.controllerManagement, this.entityFactory,this.systemSecurityContext);
+                this.controllerManagement, this.entityFactory, this.systemSecurityContext);
 
         // initiate the test
         ActionStatusUpdateEvent targetStatus = new ActionStatusUpdateEvent("default", action.getId(), Status.FINISHED,
@@ -74,7 +72,7 @@ public class ActionStatusUpdateHandlerServiceTest extends AbstractJpaIntegration
         this.distributionSetRepository.deleteById(ds.getId());
     }
 
-    private JpaDistributionSet generateDistributionSet(JpaSoftwareModule swModule, String tenant) {
+    private JpaDistributionSet generateDistributionSet(final JpaSoftwareModule swModule, final String tenant) {
         // TODO Auto-generated method stub
         JpaDistributionSet ds = new JpaDistributionSet();
         // ds.setId(distributionSetId);
@@ -88,7 +86,7 @@ public class ActionStatusUpdateHandlerServiceTest extends AbstractJpaIntegration
         return this.distributionSetRepository.save(ds);
     }
 
-    private JpaSoftwareModule generateSoftwareModule(String tenant) {
+    private JpaSoftwareModule generateSoftwareModule(final String tenant) {
         JpaSoftwareModuleType type = this.softwareModuleTypeRepository.findById(3L).get();
         JpaSoftwareModule swMod = new JpaSoftwareModule(type, "test swm", "0.0.1", "", "");
         swMod.setId(1L);
@@ -96,7 +94,8 @@ public class ActionStatusUpdateHandlerServiceTest extends AbstractJpaIntegration
         return this.softwareModuleRepository.save(swMod);
     }
 
-    private JpaAction generateAction(Long actionId, DistributionSet distributionSet, Target target, String tenant) {
+    private JpaAction generateAction(final Long actionId, final DistributionSet distributionSet, final Target target,
+            final String tenant) {
         final JpaAction action = new JpaAction();
         action.setId(actionId);
         action.setActive(true);
@@ -108,7 +107,7 @@ public class ActionStatusUpdateHandlerServiceTest extends AbstractJpaIntegration
         return actionRepository.save(action);
     }
 
-    private JpaTarget generateSampleTarget(Long id, String controllerId, String tenant) {
+    private JpaTarget generateSampleTarget(final Long id, final String controllerId, final String tenant) {
         JpaTarget jpaTarget = new JpaTarget(controllerId);
         jpaTarget.setId(id);
         jpaTarget.setTenant(tenant);

--- a/hawkbit-security-core/src/main/java/org/eclipse/hawkbit/security/SystemSecurityContext.java
+++ b/hawkbit-security-core/src/main/java/org/eclipse/hawkbit/security/SystemSecurityContext.java
@@ -11,12 +11,15 @@ package org.eclipse.hawkbit.security;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.UUID;
 import java.util.concurrent.Callable;
 
+import org.eclipse.hawkbit.im.authentication.TenantAwareAuthenticationDetails;
 import org.eclipse.hawkbit.im.authentication.SpPermission.SpringEvalExpressions;
 import org.eclipse.hawkbit.tenancy.TenantAware;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -112,11 +115,60 @@ public class SystemSecurityContext {
     }
 
     /**
+     * Runs a given {@link Callable} within a system security context, which has
+     * the provided {@link GrantedAuthority}s to successfully run the
+     * {@link Callable}.
+     * 
+     * The security context will be switched to the a new {@link SecurityContext} and back after
+     * the callable is called.
+     * 
+     * @param callable
+     *            to call within the security context
+     * @param authorities
+     *            with which the code block needs to be executed
+     * @param tenant
+     *            to act as system code
+     * @return
+     */
+    public <T> T runWithAuthority(final Callable<T> callable, final Collection<? extends GrantedAuthority> authorities,
+            final String tenant) {
+        final SecurityContext oldContext = SecurityContextHolder.getContext();
+        try {
+            LOG.debug("entering system code execution");
+            return tenantAware.runAsTenant(tenant, () -> {
+                try {
+                    setCustomSecurityContext(tenant, oldContext.getAuthentication().getPrincipal(), authorities);
+                    return callable.call();
+
+                } catch (final RuntimeException e) {
+                    throw e;
+                } catch (final Exception e) {
+                    throw new RuntimeException(e);
+                }
+            });
+
+        } finally {
+            SecurityContextHolder.setContext(oldContext);
+            LOG.debug("leaving system code execution");
+        }
+    }
+
+    /**
      * @return {@code true} if the current running code is running as system
      *         code block.
      */
     public boolean isCurrentThreadSystemCode() {
         return SecurityContextHolder.getContext().getAuthentication() instanceof SystemCodeAuthentication;
+    }
+
+    protected void setCustomSecurityContext(final String tenantId, final Object principal,
+            final Collection<? extends GrantedAuthority> authorities) {
+        final AnonymousAuthenticationToken authenticationToken = new AnonymousAuthenticationToken(
+                UUID.randomUUID().toString(), principal, authorities);
+        authenticationToken.setDetails(new TenantAwareAuthenticationDetails(tenantId, true));
+        final SecurityContextImpl securityContextImpl = new SecurityContextImpl();
+        securityContextImpl.setAuthentication(authenticationToken);
+        SecurityContextHolder.setContext(securityContextImpl);
     }
 
     private static void setSystemContext(final SecurityContext oldContext) {


### PR DESCRIPTION
This PR contains following changes:

- Adding an field to actions to be able to add an external-reference-id
- Provide the ability to update the actions-status with an internal-application event
- update securityContext to support running a callable under the context of a CONTROLLER role.