### PR TITLE
Check only DELETE_TARGET permission by validating delete permissions …

### DIFF
--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/TargetTable.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/TargetTable.java
@@ -968,7 +968,7 @@ public class TargetTable extends AbstractTable<Target> {
 
     @Override
     protected boolean hasDeletePermission() {
-        return getPermChecker().hasDeleteRepositoryPermission() || getPermChecker().hasDeleteTargetPermission();
+        return getPermChecker().hasDeleteTargetPermission();
     }
 
     @Override


### PR DESCRIPTION
Remove check for Delete_Repository permission when creating TargetTable. 

Signed-off-by: Michael Herdt <Michael.Herdt2@bosch-si.com>